### PR TITLE
Update Confluent.Kafka 1.9.3 to 2.8.0

### DIFF
--- a/MeetingRoomObserver/MeetingRoomObserver.csproj
+++ b/MeetingRoomObserver/MeetingRoomObserver.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="AutoMapper.Extensions.EnumMapping" Version="3.0.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
-    <PackageReference Include="Confluent.Kafka" Version="1.9.3" />
+    <PackageReference Include="Confluent.Kafka" Version="2.8.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Update Confluent.Kafka 1.9.3 to 2.8.0

- Adds support to KRaft